### PR TITLE
Require libatomic on Linux only.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,12 @@ include_directories(SYSTEM "${LibXML++_INCLUDEDIR}/${LIBXML++_VERSION}" ${glib_I
 
 # libatomic is required on some patforms (and doesn't hurt on the others)
 find_library(atomic-library NAMES atomic libatomic.so libatomic.so.1)
+# On some platforms, libatomic does not exist. In order to avoid an error when
+# we refer to the "atomic-library" variable on these platforms, we set it to the
+# empty string if it is not defined.
+if(NOT atomic-library)
+  set(atomic-library "")
+endif()
 
 #Includes inside the library are local includes, so we give the full path to the include directory
 include_directories(${CMAKE_SOURCE_DIR}/include/ChimeraTK/ControlSystemAdapter)


### PR DESCRIPTION
This library is neither available nor required on some other platforms (e.g. macOS), so we must only add this dependency when we actually need it.

@mhier Could please review this? I think this change is pretty straight forward, but the comment about "some platforms" needing libatomic confused me, so maybe you know whethere there are some other platforms (in addition to Linux) where we need it.