### PR TITLE
Fix persist data storage blocking the csa

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(cmake/add_dependency.cmake)
 
 set(${PROJECT_NAME}_MAJOR_VERSION 01)
 set(${PROJECT_NAME}_MINOR_VERSION 05)
-set(${PROJECT_NAME}_PATCH_VERSION 02)
+set(${PROJECT_NAME}_PATCH_VERSION 03)
 include(cmake/set_version_numbers.cmake)
 
 include(cmake/set_default_build_to_release.cmake)

--- a/include/ChimeraTK/ControlSystemAdapter/PersistentDataStorage.h
+++ b/include/ChimeraTK/ControlSystemAdapter/PersistentDataStorage.h
@@ -47,7 +47,7 @@ namespace ChimeraTK {
    public:
 
     /** unit in seconds */
-    static const unsigned int DEFAULT_WRITE_INTERVAL{10}; // 30 seconds
+    static const unsigned int DEFAULT_WRITE_INTERVAL{30}; // 30 seconds
 
     /** Constructor: Open and parse the storage file. */
     PersistentDataStorage(std::string const& applicationName, unsigned int fileWriteInterval = DEFAULT_WRITE_INTERVAL);

--- a/include/ChimeraTK/ControlSystemAdapter/PersistentDataStorage.h
+++ b/include/ChimeraTK/ControlSystemAdapter/PersistentDataStorage.h
@@ -47,7 +47,7 @@ namespace ChimeraTK {
    public:
 
     /** unit in seconds */
-    static const unsigned int DEFAULT_WRITE_INTERVAL{30}; // 30 seconds
+    static const unsigned int DEFAULT_WRITE_INTERVAL{10}; // 30 seconds
 
     /** Constructor: Open and parse the storage file. */
     PersistentDataStorage(std::string const& applicationName, unsigned int fileWriteInterval = DEFAULT_WRITE_INTERVAL);

--- a/src/PersistentDataStorage.cc
+++ b/src/PersistentDataStorage.cc
@@ -118,11 +118,10 @@ PersistentDataStorage::PersistentDataStorage(std::string const &applicationName,
 
   template<typename DataType>
   void PersistentDataStorage::generateXmlValueTags(xmlpp::Element* parent, size_t id) {
-    std::lock_guard<std::mutex> lock(_queueReadMutex);
-
+    _queueReadMutex.lock();
     // obtain the data vector from the map
     std::vector<DataType>& value = boost::fusion::at_key<DataType>(_dataMap.table)[id].read_latest();
-
+    _queueReadMutex.unlock();
     // add one child element per element of the value
     for(size_t idx = 0; idx < value.size(); ++idx) {
       xmlpp::Element* valueElement = parent->add_child("val");

--- a/src/PersistentDataStorage.cc
+++ b/src/PersistentDataStorage.cc
@@ -43,7 +43,6 @@ PersistentDataStorage::PersistentDataStorage(std::string const &applicationName,
       }
       /// @todo FIXME make the variable access proper for a multi-threaded
       /// environment!!!
-      std::lock_guard<std::mutex> lock(_queueReadMutex);
       writeToFile();
     }
   }
@@ -119,6 +118,8 @@ PersistentDataStorage::PersistentDataStorage(std::string const &applicationName,
 
   template<typename DataType>
   void PersistentDataStorage::generateXmlValueTags(xmlpp::Element* parent, size_t id) {
+    std::lock_guard<std::mutex> lock(_queueReadMutex);
+
     // obtain the data vector from the map
     std::vector<DataType>& value = boost::fusion::at_key<DataType>(_dataMap.table)[id].read_latest();
 

--- a/src/PersistentDataStorage.cc
+++ b/src/PersistentDataStorage.cc
@@ -118,15 +118,18 @@ PersistentDataStorage::PersistentDataStorage(std::string const &applicationName,
 
   template<typename DataType>
   void PersistentDataStorage::generateXmlValueTags(xmlpp::Element* parent, size_t id) {
-    _queueReadMutex.lock();
-    // obtain the data vector from the map
-    std::vector<DataType>& value = boost::fusion::at_key<DataType>(_dataMap.table)[id].read_latest();
-    _queueReadMutex.unlock();
+    std::vector<DataType>* pValue;
+    {
+      // obtain the data vector from the map
+      std::lock_guard<std::mutex> lock(_queueReadMutex);
+      std::vector<DataType>& value = boost::fusion::at_key<DataType>(_dataMap.table)[id].read_latest();
+      pValue = &value;
+    }
     // add one child element per element of the value
-    for(size_t idx = 0; idx < value.size(); ++idx) {
+    for(size_t idx = 0; idx < pValue->size(); ++idx) {
       xmlpp::Element* valueElement = parent->add_child("val");
       valueElement->set_attribute("i", boost::lexical_cast<std::string>(idx));
-      valueElement->set_attribute("v", boost::lexical_cast<std::string>(value[idx]));
+      valueElement->set_attribute("v", boost::lexical_cast<std::string>((*pValue)[idx]));
     }
   }
 


### PR DESCRIPTION
The latest version fixes #21. I'm not sure if we can accept removing the lock_guard and using the lock directly. Else handling the reference becomes a bit unhandy.