### PR TITLE
Use fixed-size integer types as template parameters

### DIFF
--- a/tests/src/testUnifiedTypeChangingDecorator.cpp
+++ b/tests/src/testUnifiedTypeChangingDecorator.cpp
@@ -222,17 +222,17 @@ BOOST_AUTO_TEST_CASE(testRegisterAccessor) {
   std::cout << "*** testRegisterAccessor *** " << std::endl;
   ChimeraTK::UnifiedBackendTest<>()
       .testOnlyTransferElement()
-      .addRegister<TestRegisterCasted<long>>()
+      .addRegister<TestRegisterCasted<int64_t>>()
       .addRegister<TestRegisterCasted<double>>()
-      .addRegister<TestRegisterRoCasted<long>>()
+      .addRegister<TestRegisterRoCasted<int64_t>>()
       .addRegister<TestRegisterRoCasted<double>>()
-      .addRegister<TestRegisterCastedAsync<long>>()
+      .addRegister<TestRegisterCastedAsync<int64_t>>()
       .addRegister<TestRegisterCastedAsync<double>>()
-      .addRegister<TestRegisterCastedAsyncRo<long>>()
+      .addRegister<TestRegisterCastedAsyncRo<int64_t>>()
       .addRegister<TestRegisterCastedAsyncRo<double>>()
-      .addRegister<TestRegisterRangeChecked<int>>()
+      .addRegister<TestRegisterRangeChecked<int32_t>>()
       .addRegister<TestRegisterRangeChecked<float>>()
-      .addRegister<TestRegisterRoRangeChecked<int>>()
+      .addRegister<TestRegisterRoRangeChecked<int32_t>>()
       .addRegister<TestRegisterRoRangeChecked<float>>()
       .runTests(cdd);
 }


### PR DESCRIPTION
The supported user-types are specified in form of the fixed-size integer types, so using variable size integer types as template parameters causes problems with some compilers. Even when using compilers that accept this kind of usage, it is sloppy because behavior will depend on the target platform.

This fixes #57.