### PR TITLE
feat: add ApplicationFactory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ project(ChimeraTK-ControlSystemAdapter)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
 set(${PROJECT_NAME}_MAJOR_VERSION 02)
-set(${PROJECT_NAME}_MINOR_VERSION 06)
-set(${PROJECT_NAME}_PATCH_VERSION 01)
+set(${PROJECT_NAME}_MINOR_VERSION 07)
+set(${PROJECT_NAME}_PATCH_VERSION 00)
 include(cmake/set_version_numbers.cmake)
 
 include(cmake/set_default_build_to_release.cmake)

--- a/include/ChimeraTK/ControlSystemAdapter/ApplicationBase.h
+++ b/include/ChimeraTK/ControlSystemAdapter/ApplicationBase.h
@@ -1,9 +1,5 @@
-/*
- * ApplicationBase.h
- *
- *  Created on: Nov 11, 2016
- *      Author: Martin Hierholzer
- */
+// SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #ifndef CHIMERA_TK_CONTROL_SYSTEM_ADAPTER_APPLICATION_BASE_H
 #define CHIMERA_TK_CONTROL_SYSTEM_ADAPTER_APPLICATION_BASE_H

--- a/include/ChimeraTK/ControlSystemAdapter/ApplicationBase.h
+++ b/include/ChimeraTK/ControlSystemAdapter/ApplicationBase.h
@@ -102,7 +102,12 @@ namespace ChimeraTK {
     static ApplicationBase* instance;
 
     /** Mutex for thread-safety when setting the instance pointer */
-    static std::mutex instance_mutex;
+    static std::recursive_mutex instanceMutex;
+
+    template<typename APPLICATION_TYPE>
+    friend class ApplicationFactory;
+
+    friend class ApplicationFactoryBase;
   };
 
 } /* namespace ChimeraTK */

--- a/include/ChimeraTK/ControlSystemAdapter/ApplicationFactory.h
+++ b/include/ChimeraTK/ControlSystemAdapter/ApplicationFactory.h
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#pragma once
+
+#include <ChimeraTK/Exception.h>
+
+#include <functional>
+#include <memory>
+#include <mutex>
+
+namespace ChimeraTK {
+
+  class ApplicationBase;
+
+  /*********************************************************************************************************************/
+
+  /** Type-less base class. Defines one static instance of the application and a
+   *  factory function to create it.
+   *  The factory function is set in the constructor of the templated ApplicationFactory
+   *  class, which then knows the actual application type and the required constructor arguments.
+   */
+  class ApplicationFactoryBase {
+   public:
+    /** Obtain instance of the ApplicationFactory. Will throw an exception if called if no instance has been created. */
+    static ApplicationBase& getApplicationInstance();
+
+    ~ApplicationFactoryBase();
+
+   protected:
+    /** Pointer to the only instance of the application.*/
+    static std::unique_ptr<ApplicationBase> _applicationInstance;
+
+    /** Mutex for thread-safety when setting the function pointer. */
+    static std::mutex _factoryFunctionMutex;
+
+    /** Create the actual application and set the instance pointer.
+     */
+    static std::function<void()> _factoryFunction;
+  };
+
+  /*********************************************************************************************************************/
+
+  /** Templated factory that allows to create an application through ApplicationFactoryBase::getApplicationInstance()
+   *  without knowing the application's type or constructor arguments.
+   *
+   *  The code implementing the application will create a static instance of the ApplicationFactory. The
+   *  adapter can then determine the time when the application constructor is actually executed. It happens on
+   *  the first call to ApplicationBase::getInstance().
+   */
+  template<typename APPLICATION_TYPE>
+  class ApplicationFactory : public ApplicationFactoryBase {
+   public:
+    /** The constructor arguments of the application are simply passed to the ApplicationFactory.
+     */
+    template<typename... APPLICATION_ARGS>
+    ApplicationFactory(APPLICATION_ARGS... args) {
+      if(_factoryFunction) {
+        throw ChimeraTK::logic_error("Multiple instances of ChimeraTK::ApplicationFactory cannot be created.");
+      }
+      std::lock_guard<std::mutex> lock(_factoryFunctionMutex);
+      _factoryFunction =
+          std::bind(&ApplicationFactory<APPLICATION_TYPE>::factoryFunctionImpl<APPLICATION_ARGS...>, this, args...);
+    }
+
+   protected:
+    template<typename... APPLICATION_ARGS>
+    void factoryFunctionImpl(APPLICATION_ARGS... args) {
+      _applicationInstance = std::make_unique<APPLICATION_TYPE>(args...);
+    }
+  };
+
+} // namespace ChimeraTK

--- a/src/ApplicationBase.cc
+++ b/src/ApplicationBase.cc
@@ -7,6 +7,8 @@
 
 #include "ApplicationBase.h"
 
+#include "ApplicationFactory.h"
+
 namespace ChimeraTK {
 
   /*********************************************************************************************************************/
@@ -67,8 +69,7 @@ namespace ChimeraTK {
 
   ApplicationBase& ApplicationBase::getInstance() {
     if(instance == nullptr) {
-      throw ChimeraTK::logic_error("No instance of ChimeraTK::ApplicationBase created, but "
-                                   "ApplicationBase::getInstance() called.");
+      return ApplicationFactoryBase::getApplicationInstance();
     }
     return *instance;
   }

--- a/src/ApplicationBase.cc
+++ b/src/ApplicationBase.cc
@@ -1,9 +1,5 @@
-/*
- * ApplicationBase.cc
- *
- *  Created on: Nov 11, 2016
- *      Author: Martin Hierholzer
- */
+// SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "ApplicationBase.h"
 

--- a/src/ApplicationBase.cc
+++ b/src/ApplicationBase.cc
@@ -14,14 +14,35 @@ namespace ChimeraTK {
   /*********************************************************************************************************************/
 
   ApplicationBase* ApplicationBase::instance = nullptr;
-  std::mutex ApplicationBase::instance_mutex;
+  std::recursive_mutex ApplicationBase::instanceMutex;
 
   /*********************************************************************************************************************/
 
   ApplicationBase::ApplicationBase(const std::string& name) : applicationName(name) {
-    std::lock_guard<std::mutex> lock(instance_mutex);
+    std::lock_guard<std::recursive_mutex> lock(instanceMutex);
+    // Protection against creating multiple instances manually
     if(instance != nullptr) {
       throw ChimeraTK::logic_error("Multiple instances of ChimeraTK::ApplicationBase cannot be created.");
+    }
+    // Protection against manual creation when a factory exists.
+    if(ApplicationFactoryBase::_factoryFunction && !ApplicationFactoryBase::_factoryIsCreating) {
+      std::cerr << "***************************************************************"
+                   "*************************************"
+                << std::endl;
+
+      std::cerr << "Logic error when creating an ApplicationBase: An ApplicationFactory already exists." << std::endl;
+      std::cerr << "You cannot use directly created Applications and an ApplicationFactory at the same time."
+                << std::endl
+                << std::endl;
+      std::cerr << "*** Remove all directly created (probably static) instances of the Application and only use the "
+                   "ApplicationFactory! ***"
+                << std::endl
+                << std::endl;
+      std::cerr << "***************************************************************"
+                   "*************************************"
+                << std::endl;
+      throw ChimeraTK::logic_error(
+          "Directly creating a ChimeraTK::Application when a ChimeraTK::ApplicationFactory exists is not allowed.");
     }
     instance = this;
   }
@@ -54,7 +75,7 @@ namespace ChimeraTK {
   void ApplicationBase::shutdown() {
     // finally clear the global instance pointer and mark this instance as shut
     // down
-    std::lock_guard<std::mutex> lock(instance_mutex);
+    std::lock_guard<std::recursive_mutex> lock(instanceMutex);
     instance = nullptr;
     hasBeenShutdown = true;
   }

--- a/src/ApplicationFactory.cc
+++ b/src/ApplicationFactory.cc
@@ -1,9 +1,5 @@
-/*
- * ApplicationBase.cc
- *
- *  Created on: Nov 11, 2016
- *      Author: Martin Hierholzer
- */
+// SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "ApplicationFactory.h"
 

--- a/src/ApplicationFactory.cc
+++ b/src/ApplicationFactory.cc
@@ -1,0 +1,52 @@
+/*
+ * ApplicationBase.cc
+ *
+ *  Created on: Nov 11, 2016
+ *      Author: Martin Hierholzer
+ */
+
+#include "ApplicationFactory.h"
+
+#include "ApplicationBase.h"
+
+namespace ChimeraTK {
+
+  /*********************************************************************************************************************/
+
+  std::unique_ptr<ApplicationBase> ApplicationFactoryBase::_applicationInstance;
+  std::mutex ApplicationFactoryBase::_factoryFunctionMutex;
+  std::function<void()> ApplicationFactoryBase::_factoryFunction;
+
+  /*********************************************************************************************************************/
+
+  ApplicationBase& ApplicationFactoryBase::getApplicationInstance() {
+    // First check whether the application instance exists before going through the
+    // effort of getting the factory lock.
+    if(_applicationInstance) {
+      return *_applicationInstance;
+    }
+
+    std::lock_guard<std::mutex> lock(_factoryFunctionMutex);
+    // Re-check that the application has not been created in the mean time (race condition)
+    if(_applicationInstance) {
+      return *_applicationInstance;
+    }
+
+    if(!_factoryFunction) {
+      throw ChimeraTK::logic_error("No instance of ApplicationFactory created, but "
+                                   "ApplicationFactoryBase::getApplicationInstance() called.");
+    }
+    _factoryFunction();
+
+    return *_applicationInstance;
+  }
+
+  /*********************************************************************************************************************/
+
+  ApplicationFactoryBase::~ApplicationFactoryBase() {
+    std::lock_guard<std::mutex> lock(_factoryFunctionMutex);
+    _factoryFunction = nullptr;
+    _applicationInstance.reset();
+  }
+
+} /* namespace ChimeraTK */

--- a/tests/src/testApplicationFactory.cc
+++ b/tests/src/testApplicationFactory.cc
@@ -11,6 +11,8 @@
 using namespace boost::unit_test_framework;
 using namespace ChimeraTK;
 
+/*********************************************************************************************************************/
+
 BOOST_AUTO_TEST_CASE(testNoFactoryNoInstance) {
   try {
     (void)ApplicationBase::getInstance();
@@ -29,6 +31,8 @@ BOOST_AUTO_TEST_CASE(testNoFactoryNoInstance) {
   }
 }
 
+/*********************************************************************************************************************/
+
 BOOST_AUTO_TEST_CASE(testFactory) {
   ApplicationFactory<ReferenceTestApplication> appFactory;
 
@@ -42,12 +46,16 @@ BOOST_AUTO_TEST_CASE(testFactory) {
   BOOST_TEST(firstCall == secondCall);
 }
 
+/*********************************************************************************************************************/
+
 class AppWithParams : public ReferenceTestApplication {
  public:
   int a;
   float b;
   AppWithParams(int a_, float b_) : a(a_), b(b_) {}
 };
+
+/*********************************************************************************************************************/
 
 BOOST_AUTO_TEST_CASE(testWithParams) {
   ApplicationFactory<AppWithParams> appFactory(3, 5.8);
@@ -57,6 +65,8 @@ BOOST_AUTO_TEST_CASE(testWithParams) {
   BOOST_TEST(withParams->a = 3);
   BOOST_TEST(withParams->b = 5.8);
 }
+
+/*********************************************************************************************************************/
 
 BOOST_AUTO_TEST_CASE(doubleFactoryInstance) {
   ApplicationFactory<ReferenceTestApplication> appFactory;
@@ -70,6 +80,8 @@ BOOST_AUTO_TEST_CASE(doubleFactoryInstance) {
   }
 }
 
+/*********************************************************************************************************************/
+
 BOOST_AUTO_TEST_CASE(doubleAppInstance) {
   ReferenceTestApplication app1;
 
@@ -81,6 +93,8 @@ BOOST_AUTO_TEST_CASE(doubleAppInstance) {
     std::cout << "Exception message debug printout: " << e.what() << std::endl;
   }
 }
+
+/*********************************************************************************************************************/
 
 BOOST_AUTO_TEST_CASE(appPlusFactory) {
   ReferenceTestApplication app;
@@ -94,6 +108,8 @@ BOOST_AUTO_TEST_CASE(appPlusFactory) {
   }
 }
 
+/*********************************************************************************************************************/
+
 BOOST_AUTO_TEST_CASE(factoryPlusApp) {
   ApplicationFactory<ReferenceTestApplication> appFactory;
 
@@ -105,6 +121,8 @@ BOOST_AUTO_TEST_CASE(factoryPlusApp) {
     std::cout << "Exception message debug printout: " << e.what() << std::endl;
   }
 }
+
+/*********************************************************************************************************************/
 
 BOOST_AUTO_TEST_CASE(testNoFactory) {
   // Legacy use case: There is an instance of the application, but no factory.

--- a/tests/src/testApplicationFactory.cc
+++ b/tests/src/testApplicationFactory.cc
@@ -1,0 +1,78 @@
+#define BOOST_TEST_MODULE TestApplicationFactory
+// Only after defining the name include the unit test header.
+#include "ApplicationFactory.h"
+#include "ReferenceTestApplication.h"
+
+#include <boost/test/included/unit_test.hpp>
+
+using namespace boost::unit_test_framework;
+using namespace ChimeraTK;
+
+BOOST_AUTO_TEST_CASE(testNoFactoryNoInstance) {
+  try {
+    (void)ApplicationBase::getInstance();
+    BOOST_ERROR("ApplicationBase::getInstance() did not throw as expected.");
+  }
+  catch(ChimeraTK::logic_error& e) {
+    std::cout << "Exception message debug printout: " << e.what() << std::endl;
+  }
+
+  try {
+    (void)ApplicationFactoryBase::getApplicationInstance();
+    BOOST_ERROR("ApplicationFactoryBase::getInstance() did not throw as expected.");
+  }
+  catch(ChimeraTK::logic_error& e) {
+    std::cout << "Exception message debug printout: " << e.what() << std::endl;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testFactory) {
+  ApplicationFactory<ReferenceTestApplication> appFactory;
+
+  auto* firstCall = &ApplicationBase::getInstance();
+
+  auto referenceAppPointer = dynamic_cast<ReferenceTestApplication*>(firstCall);
+  BOOST_TEST(referenceAppPointer != nullptr);
+
+  auto* secondCall = &ApplicationBase::getInstance();
+
+  BOOST_TEST(firstCall == secondCall);
+}
+
+class AppWithParams : public ReferenceTestApplication {
+ public:
+  int a;
+  float b;
+  AppWithParams(int a_, float b_) : a(a_), b(b_) {}
+};
+
+BOOST_AUTO_TEST_CASE(testWithParams) {
+  ApplicationFactory<AppWithParams> appFactory(3, 5.8);
+
+  auto* withParams = dynamic_cast<AppWithParams*>(&ApplicationBase::getInstance());
+  BOOST_TEST(withParams != nullptr);
+  BOOST_TEST(withParams->a = 3);
+  BOOST_TEST(withParams->b = 5.8);
+}
+
+BOOST_AUTO_TEST_CASE(doubleInstance) {
+  ApplicationFactory<ReferenceTestApplication> appFactory;
+
+  try {
+    ApplicationFactory<AppWithParams> appFactory2(3, 5.8);
+    BOOST_ERROR("ApplicationFactory constructor did not throw as expected.");
+  }
+  catch(ChimeraTK::logic_error& e) {
+    std::cout << "Exception message debug printout: " << e.what() << std::endl;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testNoFactory) {
+  // Legacy use case: There is an instance of the application, but no factory.
+
+  ReferenceTestApplication app;
+
+  BOOST_CHECK_THROW((void)ApplicationFactoryBase::getApplicationInstance(), ChimeraTK::logic_error);
+
+  BOOST_TEST(&app == &ApplicationBase::getInstance());
+}

--- a/tests/src/testApplicationFactory.cc
+++ b/tests/src/testApplicationFactory.cc
@@ -62,8 +62,8 @@ BOOST_AUTO_TEST_CASE(testWithParams) {
 
   auto* withParams = dynamic_cast<AppWithParams*>(&ApplicationBase::getInstance());
   BOOST_TEST(withParams != nullptr);
-  BOOST_TEST(withParams->a = 3);
-  BOOST_TEST(withParams->b = 5.8);
+  BOOST_TEST(withParams->a == 3);
+  BOOST_TEST(withParams->b == 5.8, boost::test_tools::tolerance(0.0001));
 }
 
 /*********************************************************************************************************************/

--- a/tests/src/testApplicationFactory.cc
+++ b/tests/src/testApplicationFactory.cc
@@ -55,12 +55,48 @@ BOOST_AUTO_TEST_CASE(testWithParams) {
   BOOST_TEST(withParams->b = 5.8);
 }
 
-BOOST_AUTO_TEST_CASE(doubleInstance) {
+BOOST_AUTO_TEST_CASE(doubleFactoryInstance) {
   ApplicationFactory<ReferenceTestApplication> appFactory;
 
   try {
     ApplicationFactory<AppWithParams> appFactory2(3, 5.8);
     BOOST_ERROR("ApplicationFactory constructor did not throw as expected.");
+  }
+  catch(ChimeraTK::logic_error& e) {
+    std::cout << "Exception message debug printout: " << e.what() << std::endl;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(doubleAppInstance) {
+  ReferenceTestApplication app1;
+
+  try {
+    AppWithParams app2(3, 5.8);
+    BOOST_ERROR("ApplicationFactory constructor did not throw as expected.");
+  }
+  catch(ChimeraTK::logic_error& e) {
+    std::cout << "Exception message debug printout: " << e.what() << std::endl;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(appPlusFactory) {
+  ReferenceTestApplication app;
+
+  try {
+    ApplicationFactory<ReferenceTestApplication> appFactory;
+    BOOST_ERROR("ApplicationFactory constructor did not throw as expected.");
+  }
+  catch(ChimeraTK::logic_error& e) {
+    std::cout << "Exception message debug printout: " << e.what() << std::endl;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(factoryPlusApp) {
+  ApplicationFactory<ReferenceTestApplication> appFactory;
+
+  try {
+    ReferenceTestApplication app;
+    BOOST_ERROR("ReferenceTestApplication constructor did not throw as expected.");
   }
   catch(ChimeraTK::logic_error& e) {
     std::cout << "Exception message debug printout: " << e.what() << std::endl;

--- a/tests/src/testApplicationFactory.cc
+++ b/tests/src/testApplicationFactory.cc
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #define BOOST_TEST_MODULE TestApplicationFactory
 // Only after defining the name include the unit test header.
 #include "ApplicationFactory.h"


### PR DESCRIPTION
By using the factory, the application is only created on the first call of getApplicationInstance(). In contrast, the constructor of a static application is run before any code can be executed, which is too early in some cases.